### PR TITLE
Update ENV declarations

### DIFF
--- a/containers/backup-cron/Dockerfile
+++ b/containers/backup-cron/Dockerfile
@@ -1,9 +1,9 @@
 FROM debian:12-slim
 
 ARG PUID=1000
-ENV PUID ${PUID}
+ENV PUID=${PUID}
 ARG PGID=1000
-ENV PGID ${PGID}
+ENV PGID=${PGID}
 
 RUN apt-get update -yqq && \
     groupadd -g ${PGID} backup-cron && \

--- a/containers/http-proxy/Dockerfile
+++ b/containers/http-proxy/Dockerfile
@@ -4,11 +4,11 @@ FROM nginx:1.11.9-alpine
 RUN apk add --no-cache --update apache2-utils
 RUN rm -f /etc/nginx/conf.d/*
 
-ENV SERVER_NAME example.com
-ENV PORT 80
-ENV CLIENT_MAX_BODY_SIZE 1m
-ENV PROXY_READ_TIMEOUT 60s
-ENV WORKER_PROCESSES 1
+ENV SERVER_NAME=example.com
+ENV PORT=80
+ENV CLIENT_MAX_BODY_SIZE=1m
+ENV PROXY_READ_TIMEOUT=60s
+ENV WORKER_PROCESSES=1
 
 COPY files/run.sh /
 COPY files/nginx.conf.tmpl /


### PR DESCRIPTION
`"ENV key=value" should be used instead of legacy "ENV key value" format` from https://docs.docker.com/reference/build-checks/legacy-key-value-format/
