### PR TITLE
Add container build CI and Dependabot; fix peq-editor build on archived Buster

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,45 @@
+# Dependabot keeps container base images and GitHub Actions versions
+# current. Each containers/* directory gets its own docker ecosystem
+# entry because Dependabot scans one directory per entry.
+
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /containers/eqemu-server
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /containers/mariadb
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /containers/http-proxy
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /containers/peq-editor
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /containers/backup-cron
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /containers/fail2ban-server
+    schedule:
+      interval: weekly
+
+  - package-ecosystem: docker
+    directory: /containers/fail2ban-mariadb
+    schedule:
+      interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,126 @@
+name: Build Container Images
+
+# Builds all akk-stack container images.
+#
+# Triggers:
+#   - Pull requests: build only (validation, no push)
+#   - Push to main:  build and push to GHCR
+#   - Weekly schedule: full rebuild and push to absorb upstream base
+#     image security patches (decoupled from repo commit velocity)
+#   - Manual dispatch: build with an optional push toggle for testing
+#
+# Images are published to ghcr.io/<repo-owner>/akk-stack/<service>
+# The namespace derives from the repository owner, so this workflow
+# works unchanged in personal mirrors, forks, and the upstream
+# EQEmu/akk-stack repo. No edits required between test and PR.
+
+on:
+  pull_request:
+    branches: [main, master]
+    paths:
+      - 'containers/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/build.yml'
+  push:
+    branches: [main, master]
+    paths:
+      - 'containers/**'
+      - 'docker-compose.yml'
+      - '.github/workflows/build.yml'
+  schedule:
+    # Weekly rebuild, Sunday 08:00 UTC
+    - cron: '0 8 * * 0'
+  workflow_dispatch:
+    inputs:
+      push_images:
+        description: 'Push built images to GHCR'
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ${{ matrix.service }}
+    runs-on: ubuntu-latest
+    strategy:
+      # One bad service should not cancel the others; we want the full
+      # failure picture in a single run.
+      fail-fast: false
+      matrix:
+        include:
+          - service: eqemu-server
+            context: ./containers/eqemu-server
+            dockerfile: ./containers/eqemu-server/Dockerfile
+          - service: mariadb
+            context: ./containers/mariadb
+            dockerfile: ./containers/mariadb/Dockerfile
+          - service: http-proxy
+            context: ./containers/http-proxy
+            dockerfile: ./containers/http-proxy/Dockerfile
+          - service: peq-editor
+            context: ./containers/peq-editor
+            dockerfile: ./containers/peq-editor/Dockerfile
+          - service: backup-cron
+            context: ./containers/backup-cron
+            dockerfile: ./containers/backup-cron/Dockerfile
+          - service: fail2ban-server
+            context: ./containers/fail2ban-server
+            dockerfile: ./containers/fail2ban-server/Dockerfile
+          - service: fail2ban-mariadb
+            context: ./containers/fail2ban-mariadb
+            dockerfile: ./containers/fail2ban-mariadb/Dockerfile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # GHCR requires a lowercase namespace and GitHub org/user names
+      # may contain uppercase characters, so normalize once here.
+      - name: Compute image name
+        id: image
+        run: |
+          OWNER_LC=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
+          echo "name=ghcr.io/${OWNER_LC}/akk-stack/${{ matrix.service }}" >> "$GITHUB_OUTPUT"
+
+      - name: Decide whether to push
+        id: push
+        run: |
+          PUSH=false
+          if [ "${{ github.event_name }}" = "push" ]; then PUSH=true; fi
+          if [ "${{ github.event_name }}" = "schedule" ]; then PUSH=true; fi
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ "${{ inputs.push_images }}" = "true" ]; then PUSH=true; fi
+          echo "push=${PUSH}" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.push.outputs.push == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ${{ matrix.context }}
+          file: ${{ matrix.dockerfile }}
+          push: ${{ steps.push.outputs.push == 'true' }}
+          tags: |
+            ${{ steps.image.outputs.name }}:latest
+            ${{ steps.image.outputs.name }}:${{ github.sha }}
+          cache-from: type=gha,scope=${{ matrix.service }}
+          cache-to: type=gha,scope=${{ matrix.service }},mode=max
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}

--- a/containers/peq-editor/Dockerfile
+++ b/containers/peq-editor/Dockerfile
@@ -4,6 +4,18 @@
 
 FROM php:7.1-apache
 
+# Debian Buster was archived after LTS ended; its package repos no
+# longer exist on deb.debian.org or security.debian.org. Point apt at
+# archive.debian.org so the image remains buildable. buster-updates
+# does not exist on the archive and is removed. Check-Valid-Until is
+# disabled because archived Release files are no longer refreshed.
+RUN sed -i \
+	-e 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' \
+	-e 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
+	/etc/apt/sources.list && \
+	sed -i '/buster-updates/d' /etc/apt/sources.list && \
+	echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
+
 RUN apt-get update && apt-get install -y \
 	libbz2-dev \
 	libc-client-dev \


### PR DESCRIPTION
What this adds

Since the Drone runners went away, none of the akk-stack container
images can be rebuilt by the community. This PR restores that
capability with a GitHub Actions workflow that:


Builds all seven container images (eqemu-server, mariadb,
http-proxy, peq-editor, backup-cron, fail2ban-server,
fail2ban-mariadb) on every pull request as build-only validation
Builds and pushes all images to GHCR on every push to main/master,
tagged latest and with the commit SHA
Rebuilds weekly (Sunday 08:00 UTC) so images absorb upstream base
image security patches independent of commit activity
Supports manual dispatch with an optional push toggle


The image namespace derives from the repository owner
(ghcr.io/OWNER/akk-stack/SERVICE), so the workflow runs unchanged in
forks and needs no secrets beyond the built-in GITHUB_TOKEN. Matrix
builds run with fail-fast disabled so one broken service does not
hide the state of the others, and build cache is scoped per service
to keep the eqemu-server job fast on reruns.

Dependabot is configured for the github-actions ecosystem and for
each container directory's docker base image, so version bumps arrive
as reviewable PRs that this same workflow then validates.

The peq-editor fix

While validating the workflow, the peq-editor image turned out to be
unbuildable by anyone: php:7.1-apache is based on Debian Buster, whose
package repositories have been removed from deb.debian.org and
security.debian.org, so the first apt-get update in the Dockerfile
fails with 404s. This PR redirects apt to archive.debian.org, removes
the buster-updates entry (not present on the archive), and disables
Acquire::Check-Valid-Until for the archived Release files. This
restores buildability without changing the PHP version; modernizing
the base image is a separate, larger conversation since the editor
code may need changes for newer PHP.

Testing

All three trigger paths were validated in a private mirror before
opening this PR:


Pull request path: full matrix build. The first run correctly
failed on the pre-existing peq-editor Buster issue (6 of 7 green);
after the Dockerfile fix, 7 of 7 green.
Push path: merge to master built and pushed all seven images to
GHCR with latest and SHA tags.
Manual dispatch path with push enabled: 7 of 7 green.


As an end-to-end confidence test, a complete fresh server install was
then performed on real hardware (Intel NUC13, Ubuntu 24.04, Docker 29)
using only the CI-built GHCR images, with all local build directives
removed from the compose file. The documented install flow
(init-reset-env, set-vars, install) completed successfully: the
server compiled, the PEQ database sourced, the loginserver
initialized, and Spire, PEQ editor, phpMyAdmin, and the FTP container
all came up. In short, a brand new server can be deployed entirely
from images this workflow produces.