### PR TITLE
Bump mariadb to 10.11 LTS; clean my.cnf; move buffer pool to runtime

### DIFF
--- a/containers/mariadb/Dockerfile
+++ b/containers/mariadb/Dockerfile
@@ -1,11 +1,6 @@
-FROM mariadb:10.5.4
+FROM mariadb:10.11
 
 LABEL maintainer="Akkadius <akkadius1@gmail.com>"
 COPY my.cnf /etc/mysql/conf.d/my.cnf
-
-ARG INNODB_BUFFER_POOL_SIZE="256MB"
-
-RUN echo "[mysqld]" >> /etc/mysql/conf.d/my.cnf && \
-	echo "innodb_buffer_pool_size  = ${INNODB_BUFFER_POOL_SIZE}" >> /etc/mysql/conf.d/my.cnf
 
 EXPOSE 3306

--- a/containers/mariadb/my.cnf
+++ b/containers/mariadb/my.cnf
@@ -1,38 +1,32 @@
 # MariaDB database server configuration file.
 #
-# You can use this file to overwrite the default configuration
+# Overrides the defaults shipped with the official mariadb image.
+# Values below preserve the effective configuration of prior
+# akk-stack deployments (duplicate keys collapsed to the values
+# that actually won, verified against a running server).
 #
-# For explanations see
-# http://dev.mysql.com/doc/mysql/en/server-system-variables.html
+# innodb_buffer_pool_size is intentionally NOT set here. It is
+# passed at runtime via the compose command flag so the .env
+# INNODB_BUFFER_POOL_SIZE variable works with prebuilt images
+# instead of being baked in at build time.
 
 [mysqld]
 port = 3306
 
-key_buffer           = 16M
+key_buffer_size      = 16M
 max_allowed_packet   = 16M
 thread_stack         = 192K
 thread_cache_size    = 8
-max_connections      = 1500
-max-user-connections = 1500
+max_connections      = 2000
 max_user_connections = 1500
-max-connections      = 2000
 
 # Optimizations
 query_cache_limit        = 10M
 query_cache_size         = 16M
 query_cache_type         = 1
 query_cache_min_res_unit = 2k
-key_buffer_size          = 16M
-max_allowed_packet       = 16M
-thread_stack             = 192K
-thread_cache_size        = 8
-max_allowed_packet       = 16M
 tmp_table_size           = 16M
 join_buffer_size         = 1M
-
-# Other Settings
-expire_logs_days = 10
-max_binlog_size  = 100M
 
 log_error = /var/log/mysql/error.log
 
@@ -43,8 +37,3 @@ skip-name-resolve
 quick
 quote-names
 max_allowed_packet = 16M
-
-[mysql]
-
-[isamchk]
-key_buffer = 16M

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -75,8 +75,7 @@ services:
     restart: unless-stopped
     build:
       context: ./containers/mariadb
-      args:
-        - INNODB_BUFFER_POOL_SIZE=${INNODB_BUFFER_POOL_SIZE:-256MB}
+    command: --innodb-buffer-pool-size=${INNODB_BUFFER_POOL_SIZE:-256MB}
     ports:
       - ${IP_ADDRESS}:3306:3306
     volumes:
@@ -88,6 +87,7 @@ services:
       - MYSQL_PASSWORD=${MARIADB_PASSWORD}
       - MYSQL_ROOT_PASSWORD=${MARIADB_ROOT_PASSWORD}
       - MYSQL_ALLOW_EMPTY_PASSWORD=NO
+      - MARIADB_AUTO_UPGRADE=1
       - TZ=${TZ:-US/Central}
     networks:
       - backend


### PR DESCRIPTION
Moves the mariadb container off 10.5.4 (series EOL) to 10.11 LTS (supported to Feb 2028). Supersedes Dependabot #18, which proposed jumping straight to 12.3; see the comments there for why a green build alone was not enough evidence for this image. 10.11 was chosen as the smallest behavioral hop off an EOL series; if there is appetite or known server support for 11.4/11.8, I am happy to re-validate against a different target, the process below is repeatable.

### What changed

1. Dockerfile: FROM mariadb:10.11. The build-time ARG that baked innodb_buffer_pool_size into the image is removed.
2. docker-compose.yml: the buffer pool now arrives at runtime via `command: --innodb-buffer-pool-size=${INNODB_BUFFER_POOL_SIZE:-256MB}`, so the .env variable works with prebuilt images (including the GHCR images CI now publishes) instead of only local builds. Also adds MARIADB_AUTO_UPGRADE=1 so the official entrypoint handles system-table upgrades automatically on version changes.
3. my.cnf: rewritten to preserve the effective configuration while removing the traps that invite misconfiguration. The old file set several keys more than once; the collapsed values below are what a running server actually reported, so behavior is unchanged:
   - max_connections stays 2000 (the old file set 1500 and then 2000 via the dash-form duplicate; 2000 won)
   - key_buffer renamed to key_buffer_size (10.11 warns on the prefix form)
   - triple max_allowed_packet collapsed to one 16M
   - expire_logs_days and max_binlog_size removed: binary logging is not enabled in this stack, so both were inert (the server says so explicitly at startup)
   - the query cache block is deliberately KEPT: it is ON in existing deployments and 10.11 defaults it off, so removing it would silently change behavior; whether to retire it is a separate conversation

### Upgrade path for existing deployments

With MARIADB_AUTO_UPGRADE=1 in the compose file, existing operators just rebuild and restart: the entrypoint detects the version change and runs mariadb-upgrade on the system tables automatically before the server starts. No manual commands. Note the auto-upgrade skips the per-table check phases for speed (they show as "Skipped" in the log); the version-compatibility fixes all run. Anyone wanting the full table sweep can run `docker compose exec mariadb mariadb-upgrade -uroot -p<root password>` once, which is what I did in testing.

If an operator boots 10.11 on old data WITHOUT the auto-upgrade (or before it runs), the error log shows `Incorrect definition of table mysql.event` and the Event Scheduler disables itself. This is the expected pre-upgrade state, not corruption; the upgrade fixes it.

### Testing

- Config audit: the legacy my.cnf was mounted into stock mariadb:10.11; the server started with no unknown-variable failures. Effective values were captured via SHOW VARIABLES from both a live 10.5.4 production deployment and the 10.11 container: character_set_server, collation_server, and sql_mode are identical across versions.
- The new image was built and booted with the exact compose runtime flag; all tracked variables matched the preserved baseline, including the buffer pool at 268435456 via the flag.
- Manual upgrade rehearsal: a copy of a real production data directory (full PEQ database) was booted on 10.11 and upgraded with mariadb-upgrade; every phase completed, all peq tables OK, and post-restart the mysql.event error and Event Scheduler failure were gone. Data verified intact (zone/item/npc counts and account data).
- Production cutover: my own server was then upgraded in place using exactly this branch (auto-upgrade path). Verified in actual gameplay: login, character creation, combat, experience gain, camp, and relog persistence.

### Known cosmetic warnings (pre-existing, not from this change)

- `You need to use --log-bin to make --expire-logs-days work`: originates from the base image's own /etc/mysql/mariadb.conf.d/50-server.cnf (verified by grep inside the image); inert without binary logging.
- `'proxies_priv' entry ... ignored in --skip-name-resolve mode`: an old privilege row naming the original container hostname; present on 10.5 as well.
- On Ubuntu 24 hosts, an io_uring EPERM warning appears (kernel.io_uring_disabled=2 default) and the server falls back to libaio.