### PR TITLE
Pin unpinned container images to specific versions

### DIFF
--- a/containers/fail2ban-mariadb/Dockerfile
+++ b/containers/fail2ban-mariadb/Dockerfile
@@ -1,3 +1,3 @@
-FROM crazymax/fail2ban:latest
+FROM crazymax/fail2ban:1.1.0
 
 COPY jail.local /etc/fail2ban/jail.local

--- a/containers/fail2ban-server/Dockerfile
+++ b/containers/fail2ban-server/Dockerfile
@@ -1,3 +1,3 @@
-FROM crazymax/fail2ban:latest
+FROM crazymax/fail2ban:1.1.0
 
 COPY jail.local /etc/fail2ban/jail.local

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
     depends_on:
       - phpmyadmin-proxy
     restart: unless-stopped
-    image: phpmyadmin/phpmyadmin:latest
+    image: phpmyadmin/phpmyadmin:5.2.3
     environment:
       - PMA_HOST=mariadb
       - PMA_USER=${MARIADB_USER}
@@ -206,7 +206,7 @@ services:
   #############################################
 
   ftp-quests:
-    image: stilliard/pure-ftpd
+    image: stilliard/pure-ftpd:bookworm-1.0.50
     restart: unless-stopped
     environment:
       FTP_USER_UID: 1000


### PR DESCRIPTION
Pins the remaining unversioned image references so deployments are reproducible and version changes arrive as reviewable diffs instead of silent :latest drift:

- crazymax/fail2ban: latest to 1.1.0 (current release) in both fail2ban Dockerfiles. These are covered by the CI matrix, so future bumps get build validation automatically.
- phpmyadmin/phpmyadmin: latest to 5.2.3 (current release of the default apache variant) in docker-compose.yml
- stilliard/pure-ftpd: untagged to bookworm-1.0.50 (current pure-ftpd release on the stable Debian base) in docker-compose.yml

Deliberately not touched: eqemulator/peq-editor:latest and eqemulator/eqemu-backup-cron:latest (and eqemu-server:v16) still point at the old Docker Hub images, which were last pushed 2025-09-29 (every tag on the same date, consistent with a final push around the maintainer transition) and have not changed since. The natural endpoint is referencing the ghcr.io/eqemu/akk-stack images this repo's CI now publishes, but that needs two things this PR cannot do: the GHCR packages made public (org-created packages default to private, needs org admin) and a decision on tag strategy (the compose pins v16 today; CI currently publishes rolling latest plus commit SHAs). Happy to do the switch as a follow-up PR once those are settled.

One note on coverage: Dependabot only scans the containers/* Dockerfiles, so the two compose-level pins (phpmyadmin, pure-ftpd) will not get automated bump PRs and need an occasional manual check. The fail2ban pins are fully automated from here.