### PR TITLE
Modernize peq-editor to PHP 8.5

### DIFF
--- a/containers/peq-editor/Dockerfile
+++ b/containers/peq-editor/Dockerfile
@@ -1,67 +1,25 @@
-######################################################
-# 7.1 Apache
-######################################################
+FROM php:8.5-apache
 
-FROM php:7.1-apache
-
-# Debian Buster was archived after LTS ended; its package repos no
-# longer exist on deb.debian.org or security.debian.org. Point apt at
-# archive.debian.org so the image remains buildable. buster-updates
-# does not exist on the archive and is removed. Check-Valid-Until is
-# disabled because archived Release files are no longer refreshed.
-RUN sed -i \
-	-e 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' \
-	-e 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' \
-	/etc/apt/sources.list && \
-	sed -i '/buster-updates/d' /etc/apt/sources.list && \
-	echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99archive
-
-RUN apt-get update && apt-get install -y \
-	libbz2-dev \
-	libc-client-dev \
-	libcurl4-gnutls-dev \
-	libkrb5-dev \
-	libmcrypt-dev \
-	libpng-dev \
-	libreadline-dev \
-	libssl-dev \
-	libxml2-dev \
-	libxslt-dev \
-	git
-
-######################################################
-# Enable / Compile PHP modules
-######################################################
-RUN docker-php-ext-install -j$(nproc) bcmath
-RUN docker-php-ext-install -j$(nproc) calendar
-RUN docker-php-ext-install -j$(nproc) curl
-RUN docker-php-ext-install -j$(nproc) dba
-RUN docker-php-ext-install -j$(nproc) exif
-RUN docker-php-ext-install -j$(nproc) gd
-RUN docker-php-ext-install -j$(nproc) gettext
-RUN docker-php-ext-install -j$(nproc) mcrypt
+# The editor code uses mysqli, json, and session. json and session are
+# built in; mysqli needs installing. opcache is NOT installed here
+# because as of PHP 8.5 it is statically compiled into PHP itself and
+# can no longer be built as a shared extension (attempting to install
+# it fails the build); the tuning below still applies to the built-in.
 RUN docker-php-ext-install -j$(nproc) mysqli
-RUN docker-php-ext-install -j$(nproc) opcache
-RUN docker-php-ext-install -j$(nproc) pdo_mysql
-RUN docker-php-ext-install -j$(nproc) soap
-RUN docker-php-ext-install -j$(nproc) sockets
-RUN docker-php-ext-install -j$(nproc) xsl
-RUN docker-php-ext-install -j$(nproc) zip
 
-RUN echo "opcache.enable=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini && \
-    echo "opcache.memory_consumption=512" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini && \
-    echo "opcache.interned_strings_buffer=64" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini && \
-    echo "opcache.max_accelerated_files=32531" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini && \
-    echo "opcache.save_comments=1" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini && \
-    echo "opcache.fast_shutdown=0" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini && \
-    echo "opcache.revalidate_freq=600000" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini && \
-    echo "opcache.validate_timestamps=0" >> /usr/local/etc/php/conf.d/docker-php-ext-opcache.ini
+# 329 files in peqphpeditor use short open tags. The compiled default
+# is On but official images ship no php.ini, so pin it explicitly
+# rather than rely on that accident.
+RUN echo "short_open_tag=On" > /usr/local/etc/php/conf.d/short-open-tag.ini
 
-######################################################
-# Apache modules
-######################################################
-RUN a2enmod deflate
-RUN a2enmod expires
-RUN a2enmod file_cache
-RUN a2enmod headers
-RUN a2enmod rewrite
+RUN { \
+    echo "opcache.enable=1"; \
+    echo "opcache.memory_consumption=512"; \
+    echo "opcache.interned_strings_buffer=64"; \
+    echo "opcache.max_accelerated_files=32531"; \
+    echo "opcache.save_comments=1"; \
+    echo "opcache.revalidate_freq=600000"; \
+    echo "opcache.validate_timestamps=0"; \
+  } > /usr/local/etc/php/conf.d/opcache-tuning.ini
+
+RUN a2enmod deflate expires file_cache headers rewrite


### PR DESCRIPTION
Follows the discussion in #19. Replaces the peq-editor base image: php:7.1-apache (EOL since 2019, built on archived Debian Buster) becomes php:8.5-apache. This also removes the archive.debian.org apt workaround added in #10, which existed only to keep the EOL image buildable, and it supersedes what Dependabot #19 attempted.

### Why the old image could never move to 8.x as-is

The Dockerfile compiled the mcrypt extension, which was removed from PHP core in 7.2. That is what failed the build on #19. Sweeping the current peqphpeditor codebase (599 PHP files): zero mcrypt usage anywhere. Of the fifteen extensions the old image compiled, the editor actually uses mysqli, json, and session, and nothing else (no GD, no PDO, no soap/zip/xsl/exif/bcmath/calendar/gettext/sockets/dba). The new image installs exactly one extension: mysqli. json and session are built in.

### Why opcache is not in the install line

As of PHP 8.5, OPcache is statically compiled into PHP itself and can no longer be built as a shared extension; docker-php-ext-install opcache now fails the build outright (verified). The old opcache tuning is carried over as conf.d settings, which still apply to the built-in, minus opcache.fast_shutdown (removed from PHP in 7.2). Anyone reviewing against muscle memory from 8.4-and-earlier images: the missing install line is deliberate.

### One deliberate config pin

short_open_tag is pinned On via conf.d: 329 editor files use short open tags. This currently works only because official php images ship no active php.ini (the compiled default is On); pinning it makes that explicit instead of accidental.

### Testing

Codebase sweep of peqphpeditor HEAD came back clean on every removed-function class (mysql_*, ereg, split, create_function, each, get_magic_quotes, curly-brace string offsets, old-style constructors). The community has also been testing the editor on PHP 8 for some time (see #19).

Packaged validation was done in this exact container shape, on both php:8.3-apache and php:8.5-apache: the image built here, mounted editor code, env-driven DB config as the compose file passes it, against a live MariaDB 10.11 PEQ database. Click-through of the main tools including real writes (faction edits saved and verified) and NPC search. The write path matters specifically because PHP 8.1 changed mysqli's default error handling to exceptions; saves exercised it. Apache error log was silent on both versions: no fatals, no warnings, no deprecation notices. opcache confirmed active as the 8.5 built-in.

This is single-session validation, not a long soak; additional testing welcome.