### PR TITLE
Source PEQ database from db.eqemu.dev instead of pinned GitLab package

### DIFF
--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -5,6 +5,11 @@ RUN_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
 $(eval $(RUN_ARGS):;@:)
 
 #----------------------
+# ProjectEQ database source
+#----------------------
+PEQ_DB_URL ?= https://db.eqemu.dev/api/v1/dump/latest
+
+#----------------------
 # Silence GNU Make
 #----------------------
 ifndef VERBOSE
@@ -106,7 +111,8 @@ init-directories: ##@init Bootstrap directories
 
 init-peq-database: ##@init Sources fresh PEQ database (Warning: Will over-write existing)
 	@./assets/scripts/banner.pl "Bootstrapping PEQ Database"
-	curl https://gitlab.com/TheGrandLibrary/db.projecteq.net-dumps/-/package_files/232952944/download -o /tmp/db.zip
+	@echo "Downloading PEQ database from [$(PEQ_DB_URL)]"
+	curl -fSL "$(PEQ_DB_URL)" -o /tmp/db.zip
 	unzip -o /tmp/db.zip -d /tmp/db/
 	cd /tmp/db/peq-dump/ && mysql -u$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.username') \
 		-p$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.password') \

--- a/assets/scripts/Makefile
+++ b/assets/scripts/Makefile
@@ -114,6 +114,8 @@ init-peq-database: ##@init Sources fresh PEQ database (Warning: Will over-write 
 	@echo "Downloading PEQ database from [$(PEQ_DB_URL)]"
 	curl -fSL "$(PEQ_DB_URL)" -o /tmp/db.zip
 	unzip -o /tmp/db.zip -d /tmp/db/
+	# Strip the MariaDB 11+ sandbox-mode header, which older mysql clients reject
+	sed -i '/^\/\*M!999999/d' /tmp/db/peq-dump/*.sql
 	cd /tmp/db/peq-dump/ && mysql -u$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.username') \
 		-p$(shell ~/assets/scripts/init/get-config-var.sh '.server.database.password') \
 		-h $(shell ~/assets/scripts/init/get-config-var.sh '.server.database.host') \


### PR DESCRIPTION
`init-peq-database` was hardcoded to a pinned package on a GitLab mirror created when db.projecteq.net went offline. ProjectEQ dumps are published again at https://db.eqemu.dev, so this sources the latest dump from there.

Changes:
- `PEQ_DB_URL` variable, defaulting to `https://db.eqemu.dev/api/v1/dump/latest`, so forks can point at their own mirror without editing the Makefile
- `curl -fSL` so a 404 fails the step instead of saving an error page that breaks later at unzip
- Strip the MariaDB sandbox-mode header (`/*M!999999\- enable the sandbox mode */`) before import. Current dumps are produced by MariaDB 10.11.18 and include this marker in several places per file; the mysql client in the eqemu-server image rejects it with `Unknown command '\-'`